### PR TITLE
fix: duplicate content with a lang different from "fr"

### DIFF
--- a/microtypo/layouts/partials/content.html
+++ b/microtypo/layouts/partials/content.html
@@ -50,8 +50,6 @@
     <!-- input.gsub!(%r!(—|&mdash;)(\s)!, '\1&nbsp;') -->
     {{ $content = $content | replaceRE "(—|&mdash;)(\\s?)" "$1&nbsp;" }}
 
-{{ else }}
-    {{ . }}
 {{ end }}
 
 


### PR DESCRIPTION
Hi @jygastaud 

I was struggling with an error of duplicate content when trying to translate the ecoinde.fr website into other languages than "fr".
It seems that doing the changes in this PR fix the problem ([see my fork here](https://github.com/cnumr/EcoIndex/pull/276/commits/89a05a3bfe6a6358e9d17716a3e8ee9c3a14c4fb#diff-87d8d58bd3960afcba2cbe3cbbaecbe060fa2c24fd7bb4c079a559cf484111ea))
However, as I just discovered Hugo and Go with the ecoindex.fr projet, I'm not completly sure that this fix is the good way to solve the issue. So if you have a better suggestion, feel free to do it instead :)